### PR TITLE
[ADD] TodayView에 필요한 현재날짜와 프로필이미지 추가

### DIFF
--- a/AppStore/AppStore.xcodeproj/project.pbxproj
+++ b/AppStore/AppStore.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		767CAFC4284F65A000522C12 /* ArcadeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767CAFC3284F65A000522C12 /* ArcadeView.swift */; };
 		767CAFC6284F65A500522C12 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767CAFC5284F65A500522C12 /* SearchView.swift */; };
 		767CAFC8284F6B6A00522C12 /* CustomIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767CAFC7284F6B6A00522C12 /* CustomIcon.swift */; };
+		767CAFCA284F80B700522C12 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767CAFC9284F80B700522C12 /* ProfileView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -31,6 +32,7 @@
 		767CAFC3284F65A000522C12 /* ArcadeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArcadeView.swift; sourceTree = "<group>"; };
 		767CAFC5284F65A500522C12 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		767CAFC7284F6B6A00522C12 /* CustomIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomIcon.swift; sourceTree = "<group>"; };
+		767CAFC9284F80B700522C12 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -65,6 +67,7 @@
 			children = (
 				767CAFAE284F63CF00522C12 /* AppStoreApp.swift */,
 				767CAFC7284F6B6A00522C12 /* CustomIcon.swift */,
+				767CAFC9284F80B700522C12 /* ProfileView.swift */,
 				767CAFB0284F63CF00522C12 /* MainTabView.swift */,
 				767CAFBD284F658300522C12 /* TodayView.swift */,
 				767CAFBF284F658900522C12 /* GameView.swift */,
@@ -177,6 +180,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				767CAFB1284F63CF00522C12 /* MainTabView.swift in Sources */,
+				767CAFCA284F80B700522C12 /* ProfileView.swift in Sources */,
 				767CAFBE284F658300522C12 /* TodayView.swift in Sources */,
 				767CAFC4284F65A000522C12 /* ArcadeView.swift in Sources */,
 				767CAFC6284F65A500522C12 /* SearchView.swift in Sources */,

--- a/AppStore/AppStore/AppView.swift
+++ b/AppStore/AppStore/AppView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct AppView: View {
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        ProfileView(selectedTabview: .app)
     }
 }
 

--- a/AppStore/AppStore/ArcadeView.swift
+++ b/AppStore/AppStore/ArcadeView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct ArcadeView: View {
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        ProfileView(selectedTabview: .arcade)
     }
 }
 

--- a/AppStore/AppStore/CustomIcon.swift
+++ b/AppStore/AppStore/CustomIcon.swift
@@ -9,9 +9,9 @@ import SwiftUI
 
 enum TabViewItemType: String {
     case today = "투데이"
-    case game
+    case game = "게임"
     case app = "앱"
-    case arcade
+    case arcade = "아케이드"
     case search = "검색"
     var image: Image {
         switch self {

--- a/AppStore/AppStore/GameView.swift
+++ b/AppStore/AppStore/GameView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct GameView: View {
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        ProfileView(selectedTabview: .game)
     }
 }
 

--- a/AppStore/AppStore/MainTabView.swift
+++ b/AppStore/AppStore/MainTabView.swift
@@ -22,11 +22,11 @@ struct MainTabView: View {
                 .tabItem {
                     TabViewItem(type: .app)
                 }
-            TodayView()
+            ArcadeView()
                 .tabItem {
                     TabViewItem(type: .arcade)
                 }
-            TodayView()
+            SearchView()
                 .tabItem {
                     TabViewItem(type: .search)
                 }

--- a/AppStore/AppStore/ProfileView.swift
+++ b/AppStore/AppStore/ProfileView.swift
@@ -16,7 +16,7 @@ let dateFormatter: DateFormatter = {
 
 struct CurrentDateView: View {
     @State var todayDate: Date = Date()
-    var body: some View{
+    var body: some View {
         HStack {
             Text("\(dateFormatter.string(from: todayDate))")
                 .font(.subheadline)

--- a/AppStore/AppStore/ProfileView.swift
+++ b/AppStore/AppStore/ProfileView.swift
@@ -1,0 +1,56 @@
+//
+//  ProfileView.swift
+//  AppStore
+//
+//  Created by yudonlee on 2022/06/07.
+//
+
+import SwiftUI
+
+let dateFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "M월 d일 EEEE"
+    formatter.locale = Locale(identifier: "ko_kr")
+    return formatter
+}()
+
+struct CurrentDateView: View {
+    @State var todayDate: Date = Date()
+    var body: some View{
+        HStack {
+            Text("\(dateFormatter.string(from: todayDate))")
+                .font(.subheadline)
+                .foregroundColor(.gray)
+            Spacer()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIApplication.significantTimeChangeNotification)
+        ) { _ in todayDate = Date() }
+    }
+}
+struct ProfileView: View {
+    var selectedTabview: TabViewItemType
+    var body: some View {
+        VStack {
+            if selectedTabview == .today {
+                CurrentDateView()
+            }
+            HStack {
+                Text("\(selectedTabview.text)")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                Spacer()
+                Image(systemName: "person.crop.circle")
+                    .font(.largeTitle)
+                    .foregroundColor(.blue)
+            }
+        }
+        .padding()
+    }
+}
+
+struct ProfileView_Previews: PreviewProvider {
+    static var previews: some View {
+        ProfileView(selectedTabview: .today)
+    }
+}
+

--- a/AppStore/AppStore/SearchView.swift
+++ b/AppStore/AppStore/SearchView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct SearchView: View {
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        ProfileView(selectedTabview: .search)
     }
 }
 

--- a/AppStore/AppStore/TodayView.swift
+++ b/AppStore/AppStore/TodayView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct TodayView: View {
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        ProfileView(selectedTabview: .today)
     }
 }
 


### PR DESCRIPTION
## 🍏 관련 이슈
- #4 

## 🍏 작업내용
- TabView를 통해 들어간 View에서 View Title과 Profile 이미지등이 나오는 뷰 생성
- ProfileView이며, 뷰의 enumeration type에 따라 구분
## 🍏 리뷰포인트
- [CurrentDateView ](https://github.com/DeveloperAcademy-POSTECH/CCC-1st-AppStore-Neal/commit/0ebfca443362c022df716cc36bff87bf0ab5f0fb#diff-777af99d560f47aabc154b5b1a187793a5d2415e149c4c9e5c57c6a6ed74958aR34)에서 실시간으로 변하는 날짜에 대응하기 위해서 State Value로 지정하고, Day가 바뀔떄마다 Notification center에서 불러오는 방식을 채택하였다.

## 🍏 다음으로 진행될 작업
- Grid생성 및 앱 설치 UI 구현

## 🍏 질문
- 없음

## 🍏 주의사항
- 없음